### PR TITLE
Use Immutable objects as now recommended

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -4,5 +4,9 @@ use Cake\Database\Type;
 
 // Allow disabling of html5-datetime-type
 if (Configure::read('lilHermit-plugin-bootstrap4.disable-html5-datetime-type') !== true) {
+    $immutable = Type::build('datetime')->getDateTimeClassName() === 'Cake\I18n\FrozenTime';
     Type::map('datetime', 'LilHermit\Bootstrap4\Database\Type\Html5DateTimeType');
+    if ($immutable) {
+        Type::build('datetime')->useImmutable();
+    }
 }


### PR DESCRIPTION
If the App's own bootstrap contains the now default `Type::build('datetime')->useImmutable();`, then the class name of the datetime type will be `Cake\I18n\FrozenTime` and so Html5DateTimeType should copy that preference.